### PR TITLE
Use cbindgen for bindings header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
 # ClipSync Monorepo Skeleton
 
 Generated on 2025-07-22
+
+## Generating C Bindings
+
+The `clip_core_bindings` crate produces a C header using
+[cbindgen](https://github.com/eqrion/cbindgen) during its build script. Run
+
+```bash
+cargo build -p clip_core_bindings
+```
+
+from the `core` directory. The resulting `bindings.h` file will appear inside
+`core/bindings` once the build completes.

--- a/core/bindings/build.rs
+++ b/core/bindings/build.rs
@@ -1,3 +1,10 @@
+use std::path::PathBuf;
+
 fn main() {
-    // Placeholder: generate C header with cbindgen here
+    let crate_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
+    let out_path = PathBuf::from(&crate_dir).join("bindings.h");
+
+    cbindgen::generate(&crate_dir)
+        .expect("Unable to generate bindings")
+        .write_to_file(out_path);
 }


### PR DESCRIPTION
## Summary
- generate C bindings header during build
- mention generated header in README

## Testing
- `cargo build -p clip_core_bindings` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_687f21a0ed7483329768a0f6766627a2