### PR TITLE
Add pairing and sync modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,35 @@
 # ClipSync Monorepo Skeleton
 
 Generated on 2025-07-22
+
+## Design Overview
+
+The `clip_core` crate implements the runtime logic for device pairing and
+clipboard message synchronization.  Networking is performed asynchronously with
+`tokio` so the same code can run on both servers and client applications.
+
+### Pairing
+
+Pairing is handled by the [`pairing` module](core/clip_core/src/pairing.rs),
+which exposes `PairingClient` and `PairingServer` structs.  The client attempts
+to connect to a server via TCP while the server waits for incoming connections.
+Authentication and persistence are not implemented yet but the stubs show where
+the logic will live.
+
+### Synchronization
+
+Message synchronization uses the [`sync` module](core/clip_core/src/sync.rs).
+`SyncClient` sends clipboard updates to a remote peer and `SyncServer` listens
+for updates.  These interactions are also performed over TCP streams to keep
+the example simple.
+
+The C bindings expose three functions:
+
+```c
+const uint8_t* clip_core_hello();
+int clip_core_pair(const char* addr);
+int clip_core_sync_send(const char* addr, const char* msg);
+```
+
+The functions create a Tokio runtime internally to execute the asynchronous
+operations.

--- a/core/bindings/src/lib.rs
+++ b/core/bindings/src/lib.rs
@@ -1,5 +1,40 @@
-use clip_core::hello;
+use clip_core::{hello, pairing::PairingClient, sync::SyncClient};
+use std::ffi::{c_char, CStr};
+
+fn runtime() -> tokio::runtime::Runtime {
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .expect("failed to build runtime")
+}
 #[no_mangle]
 pub extern "C" fn clip_core_hello() -> *const u8 {
     hello().as_ptr()
+}
+
+/// Initiates pairing with a remote device. Returns 0 on success.
+#[no_mangle]
+pub extern "C" fn clip_core_pair(addr: *const c_char) -> i32 {
+    let addr = unsafe { CStr::from_ptr(addr) };
+    let Ok(addr) = addr.to_str() else { return -1 };
+    let rt = runtime();
+    let client = PairingClient::new(addr);
+    match rt.block_on(client.pair()) {
+        Ok(_) => 0,
+        Err(_) => -1,
+    }
+}
+
+/// Sends a clipboard message to a remote device. Returns 0 on success.
+#[no_mangle]
+pub extern "C" fn clip_core_sync_send(addr: *const c_char, msg: *const c_char) -> i32 {
+    let addr = unsafe { CStr::from_ptr(addr) };
+    let msg = unsafe { CStr::from_ptr(msg) };
+    let (Ok(addr), Ok(msg)) = (addr.to_str(), msg.to_str()) else { return -1 };
+    let rt = runtime();
+    let client = SyncClient::new(addr);
+    match rt.block_on(client.send_message(msg)) {
+        Ok(_) => 0,
+        Err(_) => -1,
+    }
 }

--- a/core/clip_core/src/lib.rs
+++ b/core/clip_core/src/lib.rs
@@ -1,4 +1,9 @@
-//! Core logic placeholder
+//! Core library for ClipSync
+
+pub mod pairing;
+pub mod sync;
+
+/// Example function verifying the library was linked correctly.
 pub fn hello() -> &'static str {
     "Hello from clip_core!"
 }

--- a/core/clip_core/src/pairing.rs
+++ b/core/clip_core/src/pairing.rs
@@ -1,0 +1,38 @@
+use tokio::net::TcpStream;
+
+/// Client used for initiating device pairing.
+pub struct PairingClient {
+    remote_addr: String,
+}
+
+impl PairingClient {
+    pub fn new<A: Into<String>>(addr: A) -> Self {
+        Self { remote_addr: addr.into() }
+    }
+
+    /// Attempts to connect to a remote device to establish pairing.
+    pub async fn pair(&self) -> tokio::io::Result<()> {
+        let _stream = TcpStream::connect(&self.remote_addr).await?;
+        // Actual pairing logic would go here
+        Ok(())
+    }
+}
+
+/// Server side representation awaiting incoming pairing requests.
+pub struct PairingServer {
+    bind_addr: String,
+}
+
+impl PairingServer {
+    pub fn new<A: Into<String>>(addr: A) -> Self {
+        Self { bind_addr: addr.into() }
+    }
+
+    /// Starts listening for pairing requests from remote devices.
+    pub async fn listen(&self) -> tokio::io::Result<()> {
+        let listener = tokio::net::TcpListener::bind(&self.bind_addr).await?;
+        let _ = listener.accept().await?;
+        // Real implementation would authenticate the connecting client
+        Ok(())
+    }
+}

--- a/core/clip_core/src/sync.rs
+++ b/core/clip_core/src/sync.rs
@@ -1,0 +1,40 @@
+use tokio::net::TcpStream;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+/// Client used for sending clipboard updates to a remote device.
+pub struct SyncClient {
+    remote_addr: String,
+}
+
+impl SyncClient {
+    pub fn new<A: Into<String>>(addr: A) -> Self {
+        Self { remote_addr: addr.into() }
+    }
+
+    /// Sends a clipboard message to the remote device.
+    pub async fn send_message(&self, message: &str) -> tokio::io::Result<()> {
+        let mut stream = TcpStream::connect(&self.remote_addr).await?;
+        stream.write_all(message.as_bytes()).await?;
+        Ok(())
+    }
+}
+
+/// Server that accepts incoming clipboard messages.
+pub struct SyncServer {
+    bind_addr: String,
+}
+
+impl SyncServer {
+    pub fn new<A: Into<String>>(addr: A) -> Self {
+        Self { bind_addr: addr.into() }
+    }
+
+    /// Waits for a single clipboard message from a remote client.
+    pub async fn receive_message(&self) -> tokio::io::Result<String> {
+        let listener = tokio::net::TcpListener::bind(&self.bind_addr).await?;
+        let (mut socket, _) = listener.accept().await?;
+        let mut buf = String::new();
+        socket.read_to_string(&mut buf).await?;
+        Ok(buf)
+    }
+}


### PR DESCRIPTION
## Summary
- implement new `pairing` and `sync` modules in `clip_core`
- expose FFI for device pairing and clipboard sync
- document high level design in README

## Testing
- `cargo fmt --all` *(fails: rustfmt missing)*
- `cargo check --workspace` *(fails: could not download index)*

------
https://chatgpt.com/codex/tasks/task_e_687f21ad78908332b5058a67e63a891c