### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,30 @@
+name: Build Apps
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  android:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+      - name: Build Rust core
+        run: cargo build -p clip_core --manifest-path core/Cargo.toml
+      - name: Build Android app
+        run: cd platforms/android && ./gradlew assembleDebug
+
+  macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build Rust core
+        run: cargo build -p clip_core --manifest-path core/Cargo.toml
+      - name: Build macOS app
+        run: cd platforms/mac && swift build -c release


### PR DESCRIPTION
## Summary
- build Android and macOS applications in CI using GitHub Actions

## Testing
- `cargo test -p clip_core --manifest-path core/Cargo.toml` *(fails: failed to download from https://index.crates.io)*

------
https://chatgpt.com/codex/tasks/task_e_687f271bcdcc8332a8fbc6e6eddf83c4