### PR TITLE
Fix Tokio imports

### DIFF
--- a/core/bindings/Cargo.toml
+++ b/core/bindings/Cargo.toml
@@ -8,6 +8,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 clip_core = { path = "../clip_core" }
+tokio = { version = "1.38", default-features = false, features = ["net", "io-util", "rt-multi-thread"] }
 
 [build-dependencies]
 cbindgen = "0.26"

--- a/core/clip_core/Cargo.toml
+++ b/core/clip_core/Cargo.toml
@@ -4,4 +4,4 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-tokio = { version = "1.38", default-features = false, features = ["net"] }
+tokio = { version = "1.38", default-features = false, features = ["net", "io-util", "rt-multi-thread"] }


### PR DESCRIPTION
## Summary
- enable io util features in `clip_core`
- add Tokio dependency in bindings

## Testing
- `cargo build -p clip_core --manifest-path core/Cargo.toml` *(fails: network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_687f28f88a608332b630bb2a871ee881