### PR TITLE
Add pairing GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,19 @@ You can also install [`just`](https://github.com/casey/just) and run:
 just build-all
 ```
 
+### Pairing GUI
+
+An experimental desktop GUI for initiating device pairing is located in
+`scripts/pair_gui.py`. Build the bindings crate so the dynamic library is
+available and then run the script:
+
+```bash
+cargo build -p clip_core_bindings
+python scripts/pair_gui.py
+```
+
+Enter the server address and click **Pair** to connect to a remote device.
+
 ## Future Goals
 
 This repository currently contains placeholder implementations. Planned work includes secure device pairing, clipboard synchronization across devices, and improved user interfaces on each platform.

--- a/scripts/pair_gui.py
+++ b/scripts/pair_gui.py
@@ -1,0 +1,62 @@
+import ctypes
+import os
+from tkinter import Tk, Label, Entry, Button, StringVar, messagebox
+
+
+def _load_library() -> ctypes.CDLL:
+    """Load the clip_core_bindings dynamic library."""
+    lib_name = {
+        'darwin': 'libclip_core_bindings.dylib',
+        'linux': 'libclip_core_bindings.so',
+        'win32': 'clip_core_bindings.dll',
+    }.get(os.sys.platform)
+    if lib_name is None:
+        raise RuntimeError(f"Unsupported platform: {os.sys.platform}")
+
+    # Look for the library inside core/bindings/target/debug by default
+    repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+    candidate = os.path.join(
+        repo_root, 'core', 'bindings', 'target', 'debug', lib_name
+    )
+    if not os.path.exists(candidate):
+        raise FileNotFoundError(
+            f"Could not find {lib_name}. Build the bindings crate first."
+        )
+    return ctypes.CDLL(candidate)
+
+
+lib = _load_library()
+_pair = lib.clip_core_pair
+_pair.argtypes = [ctypes.c_char_p]
+_pair.restype = ctypes.c_int
+
+
+def pair_device(addr: str) -> bool:
+    result = _pair(addr.encode())
+    return result == 0
+
+
+def main() -> None:
+    root = Tk()
+    root.title("ClipSync Pairing")
+
+    Label(root, text="Server address:").grid(row=0, column=0, padx=5, pady=5)
+    addr_var = StringVar()
+    Entry(root, textvariable=addr_var, width=40).grid(row=0, column=1, padx=5, pady=5)
+
+    def do_pair():
+        addr = addr_var.get().strip()
+        if not addr:
+            messagebox.showerror("Pairing", "Please enter an address")
+            return
+        if pair_device(addr):
+            messagebox.showinfo("Pairing", "Pairing successful")
+        else:
+            messagebox.showerror("Pairing", "Pairing failed")
+
+    Button(root, text="Pair", command=do_pair).grid(row=1, column=0, columnspan=2, pady=10)
+    root.mainloop()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- introduce a small Tkinter-based GUI for pairing devices via `clip_core_bindings`
- document how to build and run the GUI in the README

## Testing
- `cargo check --manifest-path core/clip_core/Cargo.toml` *(fails: could not download crates)*
- `python -m py_compile scripts/pair_gui.py`

------
https://chatgpt.com/codex/tasks/task_e_687f2b5d8dcc8332a2df4d4fb2b3f4ba