### PR TITLE
Define repositories for Android module

### DIFF
--- a/platforms/android/app/build.gradle.kts
+++ b/platforms/android/app/build.gradle.kts
@@ -3,6 +3,11 @@ plugins {
     kotlin("android")
 }
 
+repositories {
+    google()
+    mavenCentral()
+}
+
 android {
     namespace = "com.mouse.clipsync"
     compileSdk = 34


### PR DESCRIPTION
## Summary
- ensure that the Android module can resolve dependencies by adding google() and mavenCentral() repositories

## Testing
- `cargo test --manifest-path core/clip_core/Cargo.toml` *(fails: unable to download tokio crate)*
- `cd platforms/android && ./gradlew tasks --no-daemon` *(fails: cannot download Gradle distribution)*

------
https://chatgpt.com/codex/tasks/task_e_687f487ec3a8833295e1b87a3c69ec18