### PR TITLE
Enable AndroidX for Android build

### DIFF
--- a/platforms/android/gradle.properties
+++ b/platforms/android/gradle.properties
@@ -3,3 +3,7 @@
 
 org.gradle.configuration-cache=true
 
+# Enable AndroidX support for libraries and plugins
+android.useAndroidX=true
+android.enableJetifier=true
+


### PR DESCRIPTION
## Summary
- enable AndroidX in the Android gradle properties

## Testing
- `./gradlew assembleDebug --dry-run` *(fails: Unable to tunnel through proxy)*
- `cargo check -p clip_core --manifest-path core/Cargo.toml` *(fails: failed to download from crates.io)*

------
https://chatgpt.com/codex/tasks/task_e_687f5e655d5c8332b7c98b61d7f857f9