### PR TITLE
Fix Android jvmTarget mismatch

### DIFF
--- a/platforms/android/app/build.gradle.kts
+++ b/platforms/android/app/build.gradle.kts
@@ -19,6 +19,15 @@ android {
         versionCode = 1
         versionName = "0.1.0"
     }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = "17"
+    }
 }
 
 dependencies {


### PR DESCRIPTION
## Summary
- align Java compile options with Kotlin jvmTarget

## Testing
- `./gradlew assembleDebug` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_687f64e80c548332998e0d799b2ff80c