### PR TITLE
Fix Android build by adding Compose dependencies

### DIFF
--- a/platforms/android/app/build.gradle.kts
+++ b/platforms/android/app/build.gradle.kts
@@ -28,8 +28,23 @@ android {
     kotlinOptions {
         jvmTarget = "17"
     }
+
+    buildFeatures {
+        compose = true
+    }
+
+    composeOptions {
+        kotlinCompilerExtensionVersion = "1.5.10"
+    }
 }
 
 dependencies {
     implementation("androidx.core:core-ktx:1.13.1")
+
+    val composeBom = platform("androidx.compose:compose-bom:2024.05.00")
+    implementation(composeBom)
+    androidTestImplementation(composeBom)
+
+    implementation("androidx.activity:activity-compose")
+    implementation("androidx.compose.material3:material3")
 }


### PR DESCRIPTION
## Summary
- add Jetpack Compose support in the Android app module
- include Compose BOM and Material3 dependencies

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f683367a0833296d275958d60ba2b