### PR TITLE
Fix Android build warnings

### DIFF
--- a/platforms/android/app/build.gradle.kts
+++ b/platforms/android/app/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("com.android.application")
     kotlin("android")
+    id("org.jetbrains.kotlin.plugin.compose")
 }
 
 repositories {

--- a/platforms/android/build.gradle.kts
+++ b/platforms/android/build.gradle.kts
@@ -1,4 +1,5 @@
 plugins {
-    id("com.android.application") version "8.6.0" apply false
-    kotlin("android") version "2.0.0" apply false
+    id("com.android.application") version "8.11.1" apply false
+    kotlin("android") version "2.0.21" apply false
+    id("org.jetbrains.kotlin.plugin.compose") version "2.0.21" apply false
 }


### PR DESCRIPTION
## Summary
- update Gradle plugin and Kotlin versions
- enable Compose plugin for Kotlin 2.0+

## Testing
- `./gradlew tasks --warning-mode all`
- `cargo test --no-run`

------
https://chatgpt.com/codex/tasks/task_e_687f6dd049048332b90c7f8c628b5bb9