### PR TITLE
Upload artifacts from CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,11 @@ jobs:
         run: cargo build -p clip_core --manifest-path core/Cargo.toml
       - name: Build Android app
         run: cd platforms/android && ./gradlew assembleDebug
+      - name: Upload Android APK
+        uses: actions/upload-artifact@v3
+        with:
+          name: android-apk
+          path: platforms/android/app/build/outputs/apk/debug/app-debug.apk
 
   macos:
     runs-on: macos-latest
@@ -28,3 +33,8 @@ jobs:
         run: cargo build -p clip_core --manifest-path core/Cargo.toml
       - name: Build macOS app
         run: cd platforms/mac && swift build -c release
+      - name: Upload macOS binary
+        uses: actions/upload-artifact@v3
+        with:
+          name: macos-binary
+          path: platforms/mac/.build/release/ClipboardMac

--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ You can also install [`just`](https://github.com/casey/just) and run:
 just build-all
 ```
 
+### GitHub Actions artifacts
+
+Every workflow run uploads the build outputs as artifacts. Visit the run summary
+on GitHub Actions to download `android-apk` (the debug APK) and `macos-binary`
+(the compiled macOS executable).
+
 ### Pairing GUI
 
 An experimental desktop GUI for initiating device pairing is located in


### PR DESCRIPTION
## Summary
- upload built APK and macOS binary as workflow artifacts
- document where CI outputs can be downloaded

## Testing
- `cargo check -p clip_core --manifest-path core/Cargo.toml`
- `swift build`

------
https://chatgpt.com/codex/tasks/task_e_68802cbff3988332ba612199bf836ed2