### PR TITLE
Add BLE GUI stubs for macOS and Android

### DIFF
--- a/core/bindings/src/lib.rs
+++ b/core/bindings/src/lib.rs
@@ -1,4 +1,4 @@
-use clip_core::{hello, pairing::PairingClient, sync::SyncClient};
+use clip_core::{hello, pairing::PairingClient, sync::SyncClient, ble::BleClient};
 use std::ffi::{c_char, CStr};
 
 fn runtime() -> tokio::runtime::Runtime {
@@ -34,6 +34,30 @@ pub extern "C" fn clip_core_sync_send(addr: *const c_char, msg: *const c_char) -
     let rt = runtime();
     let client = SyncClient::new(addr);
     match rt.block_on(client.send_message(msg)) {
+        Ok(_) => 0,
+        Err(_) => -1,
+    }
+}
+
+/// Performs BLE pairing with a nearby device. Returns 0 on success.
+#[no_mangle]
+pub extern "C" fn clip_core_ble_pair() -> i32 {
+    let rt = runtime();
+    let client = BleClient::default();
+    match rt.block_on(client.pair()) {
+        Ok(_) => 0,
+        Err(_) => -1,
+    }
+}
+
+/// Sends a message via BLE to a paired device. Returns 0 on success.
+#[no_mangle]
+pub extern "C" fn clip_core_ble_send(msg: *const c_char) -> i32 {
+    let msg = unsafe { CStr::from_ptr(msg) };
+    let Ok(msg) = msg.to_str() else { return -1 };
+    let rt = runtime();
+    let client = BleClient::default();
+    match rt.block_on(client.send_message(msg.as_bytes())) {
         Ok(_) => 0,
         Err(_) => -1,
     }

--- a/core/clip_core/Cargo.toml
+++ b/core/clip_core/Cargo.toml
@@ -5,3 +5,6 @@ edition = "2021"
 
 [dependencies]
 tokio = { version = "1.38", default-features = false, features = ["net", "io-util", "rt-multi-thread"] }
+btleplug = "0.11"
+uuid = { version = "1", features = ["serde", "v4"] }
+anyhow = "1"

--- a/core/clip_core/src/ble.rs
+++ b/core/clip_core/src/ble.rs
@@ -1,0 +1,77 @@
+use btleplug::api::{Central, Manager as _, Peripheral as _, ScanFilter, WriteType};
+use btleplug::platform::Manager;
+use tokio::time::{sleep, Duration};
+use uuid::Uuid;
+
+/// Default service UUID used for discovering remote devices.
+const SERVICE_UUID: Uuid = Uuid::from_u128(0xfeed_cafe_dead_beef_feed_cafe_dead_beef);
+/// Characteristic UUID used for message writes.
+const CHARACTERISTIC_UUID: Uuid = Uuid::from_u128(0xfeed_cafe_dead_beef_feed_cafe_dead_bead);
+
+/// Simple BLE client for pairing and sending data.
+pub struct BleClient {
+    service_uuid: Uuid,
+    char_uuid: Uuid,
+}
+
+impl Default for BleClient {
+    fn default() -> Self {
+        Self { service_uuid: SERVICE_UUID, char_uuid: CHARACTERISTIC_UUID }
+    }
+}
+
+impl BleClient {
+    /// Scan for the first peripheral advertising the service and connect.
+    pub async fn pair(&self) -> anyhow::Result<()> {
+        let manager = Manager::new().await?;
+        let adapter = manager
+            .adapters()
+            .await?
+            .into_iter()
+            .next()
+            .ok_or_else(|| anyhow::anyhow!("No Bluetooth adapters found"))?;
+        adapter.start_scan(ScanFilter::default()).await?;
+        sleep(Duration::from_secs(2)).await;
+        for peripheral in adapter.peripherals().await? {
+            if let Some(props) = peripheral.properties().await? {
+                if props.services.iter().any(|s| *s == self.service_uuid) {
+                    peripheral.connect().await?;
+                    peripheral.disconnect().await?;
+                    return Ok(());
+                }
+            }
+        }
+        Err(anyhow::anyhow!("Matching BLE device not found"))
+    }
+
+    /// Connects to the peripheral and writes a message to the characteristic.
+    pub async fn send_message(&self, message: &[u8]) -> anyhow::Result<()> {
+        let manager = Manager::new().await?;
+        let adapter = manager
+            .adapters()
+            .await?
+            .into_iter()
+            .next()
+            .ok_or_else(|| anyhow::anyhow!("No Bluetooth adapters found"))?;
+        adapter.start_scan(ScanFilter::default()).await?;
+        sleep(Duration::from_secs(2)).await;
+        for peripheral in adapter.peripherals().await? {
+            if let Some(props) = peripheral.properties().await? {
+                if props.services.iter().any(|s| *s == self.service_uuid) {
+                    peripheral.connect().await?;
+                    peripheral.discover_services().await?;
+                    if let Some(ch) = peripheral
+                        .characteristics()
+                        .into_iter()
+                        .find(|c| c.uuid == self.char_uuid)
+                    {
+                        peripheral.write(&ch, message, WriteType::WithResponse).await?;
+                    }
+                    peripheral.disconnect().await?;
+                    return Ok(());
+                }
+            }
+        }
+        Err(anyhow::anyhow!("Matching BLE device not found"))
+    }
+}

--- a/core/clip_core/src/lib.rs
+++ b/core/clip_core/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod pairing;
 pub mod sync;
+pub mod ble;
 
 /// Example function verifying the library was linked correctly.
 pub fn hello() -> &'static str {

--- a/platforms/android/app/build.gradle.kts
+++ b/platforms/android/app/build.gradle.kts
@@ -48,4 +48,5 @@ dependencies {
 
     implementation("androidx.activity:activity-compose")
     implementation("androidx.compose.material3:material3")
+    implementation("net.java.dev.jna:jna:5.13.0")
 }

--- a/platforms/android/app/src/main/java/com/mouse/clipboard/MainActivity.kt
+++ b/platforms/android/app/src/main/java/com/mouse/clipboard/MainActivity.kt
@@ -3,13 +3,72 @@ package com.mouse.clipsync
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.sun.jna.Library
+import com.sun.jna.Native
+
+interface ClipCoreBindings : Library {
+    fun clip_core_ble_pair(): Int
+    fun clip_core_ble_send(msg: String): Int
+}
 
 class MainActivity : ComponentActivity() {
+    private val bindings: ClipCoreBindings by lazy {
+        Native.load("clip_core_bindings", ClipCoreBindings::class.java)
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
-            Text("Clipboard Android placeholder")
+            var status by remember { mutableStateOf("Not paired") }
+            var message by remember { mutableStateOf("") }
+
+            MaterialTheme {
+                Column(modifier = Modifier.padding(16.dp)) {
+                    Button(onClick = {
+                        status = if (bindings.clip_core_ble_pair() == 0) {
+                            "Paired"
+                        } else {
+                            "Pair failed"
+                        }
+                    }) {
+                        Text("Pair")
+                    }
+
+                    Text(status, modifier = Modifier.padding(top = 8.dp))
+
+                    OutlinedTextField(
+                        value = message,
+                        onValueChange = { message = it },
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(top = 8.dp),
+                        label = { Text("Message") }
+                    )
+
+                    Button(
+                        onClick = {
+                            status = if (bindings.clip_core_ble_send(message) == 0) {
+                                "Sent"
+                            } else {
+                                "Send failed"
+                            }
+                        },
+                        modifier = Modifier.padding(top = 8.dp)
+                    ) {
+                        Text("Send")
+                    }
+                }
+            }
         }
     }
 }

--- a/platforms/mac/Package.swift
+++ b/platforms/mac/Package.swift
@@ -11,7 +11,10 @@ let package = Package(
     targets: [
         .executableTarget(
             name: "App",
-            path: "Sources/App"
+            path: "Sources/App",
+            linkerSettings: [
+                .unsafeFlags(["-L../../core/bindings/target/debug", "-lclip_core_bindings"])
+            ]
         )
     ]
 )

--- a/platforms/mac/Sources/App/main.swift
+++ b/platforms/mac/Sources/App/main.swift
@@ -1,3 +1,48 @@
-import Foundation
+import SwiftUI
 
-print("Clipboard mac placeholder")
+@_silgen_name("clip_core_ble_pair")
+func clip_core_ble_pair() -> Int32
+
+@_silgen_name("clip_core_ble_send")
+func clip_core_ble_send(_ msg: UnsafePointer<CChar>) -> Int32
+
+struct ContentView: View {
+    @State private var status = "Not paired"
+    @State private var message = ""
+
+    var body: some View {
+        VStack(spacing: 12) {
+            Text("BLE Pairing Demo")
+            Button("Pair") {
+                if clip_core_ble_pair() == 0 {
+                    status = "Paired"
+                } else {
+                    status = "Pair failed"
+                }
+            }
+            Text(status)
+            TextField("Message", text: $message)
+                .textFieldStyle(.roundedBorder)
+            Button("Send") {
+                message.withCString { ptr in
+                    if clip_core_ble_send(ptr) == 0 {
+                        status = "Sent";
+                    } else {
+                        status = "Send failed";
+                    }
+                }
+            }
+        }
+        .padding()
+        .frame(width: 300)
+    }
+}
+
+@main
+struct ClipboardMacApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- link mac app with bindings library and implement SwiftUI BLE interface
- update Android Compose app with JNA to call BLE functions
- include JNA dependency

## Testing
- `cargo build -p clip_core --manifest-path core/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_6880540debe88332acaef77fc5ef310e